### PR TITLE
Revert "CORE-660: added a database table for job limits"

### DIFF
--- a/database/migrations/000003_add_job_limits_table.down.sql
+++ b/database/migrations/000003_add_job_limits_table.down.sql
@@ -1,1 +1,0 @@
-DROP TABLE IF EXISTS job_limits;

--- a/database/migrations/000003_add_job_limits_table.up.sql
+++ b/database/migrations/000003_add_job_limits_table.up.sql
@@ -1,8 +1,0 @@
-CREATE TABLE IF NOT EXISTS job_limits (
-       id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-       launcher STRING UNIQUE DEFAULT NULL,
-       concurrent_jobs INT NOT NULL
-);
-
--- The default job limits.
-UPSERT INTO job_limits (concurrent_jobs) VALUES (8);


### PR DESCRIPTION
This reverts commit 755b2f4253a95dfc4cb5010038ce7e3f4d373455.

It turns out that I updated the wrong database. 😊 The DE database should have been updated instead.
