### PR TITLE
Periodic VICE notifications

### DIFF
--- a/analyses.go
+++ b/analyses.go
@@ -170,7 +170,7 @@ SELECT jobs.id,
   LEFT join notif_statuses ON jobs.id = notif_statuses.analysis_id
  WHERE jobs.status = $1
    AND (notif_statuses.last_periodic_warning is null
-    OR notif_statuses.last_periodic_warning < now() - (coalesce(notif_statuses.periodic_warning_period, 14400)::text || ' seconds'::text)::interval)
+    OR notif_statuses.last_periodic_warning < now() - coalesce(notif_statuses.periodic_warning_period, '4 hours'::interval))
 `
 
 // JobPeriodicWarnings returns a list of running jobs that may need periodic notifications to be sent

--- a/analyses.go
+++ b/analyses.go
@@ -170,7 +170,7 @@ SELECT jobs.id,
   LEFT join notif_statuses ON jobs.id = notif_statuses.analysis_id
  WHERE jobs.status = $1
    AND (notif_statuses.last_periodic_warning is null
-    OR notif_statuses.last_periodic_warning < $2 - (coalesce(notif_statuses.periodic_warning_period, 14400)::text || ' seconds'::text)::interval)
+    OR notif_statuses.last_periodic_warning < now() - (coalesce(notif_statuses.periodic_warning_period, 14400)::text || ' seconds'::text)::interval)
 `
 
 // JobPeriodicWarnings returns a list of running jobs that may need periodic notifications to be sent
@@ -180,12 +180,10 @@ func JobPeriodicWarnings(ctx context.Context, dedb *sql.DB) ([]Job, error) {
 		rows *sql.Rows
 	)
 
-	now := time.Now()
 	if rows, err = dedb.QueryContext(
 		ctx,
 		periodicWarningsQuery,
 		"Running",
-		now,
 	); err != nil {
 		return nil, err
 	}

--- a/analyses.go
+++ b/analyses.go
@@ -152,6 +152,95 @@ func JobsToKill(ctx context.Context, dedb *sql.DB) ([]Job, error) {
 	return jobs, nil
 }
 
+const periodicWarningsQuery = `
+SELECT jobs.id,
+       jobs.app_id,
+       jobs.user_id,
+       jobs.status,
+       jobs.job_description,
+       jobs.job_name,
+       jobs.result_folder_path,
+       jobs.planned_end_date,
+       jobs.start_date,
+       job_types.system_id,
+       users.username
+  FROM jobs
+  JOIN job_types on jobs.job_type_id = job_types.id
+  JOIN users on jobs.user_id = users.id
+  LEFT join notif_statuses ON jobs.id = notif_statuses.analysis_id
+ WHERE jobs.status = $1
+   AND (notif_statuses.last_periodic_warning is null
+    OR notif_statuses.last_periodic_warning < $2 - (coalesce(notif_statuses.periodic_warning_period, 14400)::text || ' seconds'::text)::interval)
+`
+
+// JobPeriodicWarnings returns a list of running jobs that may need periodic notifications to be sent
+func JobPeriodicWarnings(ctx context.Context, dedb *sql.DB) ([]Job, error) {
+	var (
+		err  error
+		rows *sql.Rows
+	)
+
+	now := time.Now()
+	if rows, err = dedb.QueryContext(
+		ctx,
+		periodicWarningsQuery,
+		"Running",
+		now,
+	); err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	jobs := []Job{}
+
+	for rows.Next() {
+		var (
+			job            Job
+			startDate      pq.NullTime
+			plannedEndDate pq.NullTime
+		)
+
+		job = Job{}
+
+		if err = rows.Scan(
+			&job.ID,
+			&job.AppID,
+			&job.UserID,
+			&job.Status,
+			&job.Description,
+			&job.Name,
+			&job.ResultFolder,
+			&plannedEndDate,
+			&startDate,
+			&job.Type,
+			&job.User,
+		); err != nil {
+			return nil, err
+		}
+
+		if plannedEndDate.Valid {
+			job.PlannedEndDate = plannedEndDate.Time.Format(TimestampFromDBFormat)
+		}
+
+		if startDate.Valid {
+			job.StartDate = startDate.Time.Format(TimestampFromDBFormat)
+		}
+
+		job.ExternalID, err = getExternalID(ctx, dedb, job.ID)
+		if err != nil {
+			return nil, err
+		}
+
+		jobs = append(jobs, job)
+	}
+
+	if err = rows.Err(); err != nil {
+		return nil, err
+	}
+
+	return jobs, nil
+}
+
 const jobWarningsQuery = `
 select jobs.id,
        jobs.app_id,

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/cyverse-de/messaging/v9 v9.1.5
 	github.com/lib/pq v1.10.4
 	github.com/pkg/errors v0.9.1
+	github.com/sanyokbig/pqinterval v1.1.2
 	github.com/sirupsen/logrus v1.4.2
 	github.com/spf13/viper v1.4.0
 	github.com/streadway/amqp v1.0.1-0.20200716223359-e6b33f460591

--- a/go.sum
+++ b/go.sum
@@ -102,6 +102,8 @@ github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R
 github.com/prometheus/procfs v0.0.0-20190507164030-5867b95ac084/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
+github.com/sanyokbig/pqinterval v1.1.2 h1:RzHMPdRMNvSZSDE+Qr20fFWSfBkKPFrLdFhzqmF0VnY=
+github.com/sanyokbig/pqinterval v1.1.2/go.mod h1:jJvMjZaZFVqNTNVCd90zcFOkmbJgjxlWWkpu9/VeUFs=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.2 h1:SPIRibHv4MatM3XXNO2BJeFLZwZ2LvZgfQ5+UNI2im4=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
@@ -126,6 +128,7 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/objx v0.1.1 h1:2vfRuCMp5sSVIDSqO8oNnWJq7mPa6KVP3iPIwFBuy8A=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
+github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1 h1:5TQK59W5E3v0r2duFAb7P95B6hEeOyEnHRa8MjYSMTY=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=

--- a/main.go
+++ b/main.go
@@ -303,6 +303,10 @@ func sendPeriodic(ctx context.Context, db *sql.DB, vicedb *VICEDatabaser) {
 			}
 
 			sd, err := time.Parse(TimestampFromDBFormat, j.StartDate)
+			if err != nil {
+				log.Errorf(errors.Wrap(err, "Error parsing start date %s", j.StartDate))
+				continue
+			}
 			comparisonTimestamp = sd
 			if notifStatuses.LastPeriodicWarning.After(sd) {
 				comparisonTimestamp = notifStatuses.LastPeriodicWarning
@@ -321,7 +325,11 @@ func sendPeriodic(ctx context.Context, db *sql.DB, vicedb *VICEDatabaser) {
 					continue
 				}
 				// update timestamp:
-				vicedb.UpdateLastPeriodicWarning(ctx, &j, now)
+				err = vicedb.UpdateLastPeriodicWarning(ctx, &j, now)
+				if err != nil {
+					log.Error(errors.Wrap(err, "Error updating periodic notification timestamp"))
+					continue
+				}
 			}
 		}
 	}

--- a/main.go
+++ b/main.go
@@ -304,7 +304,7 @@ func sendPeriodic(ctx context.Context, db *sql.DB, vicedb *VICEDatabaser) {
 
 			sd, err := time.Parse(TimestampFromDBFormat, j.StartDate)
 			if err != nil {
-				log.Errorf(errors.Wrap(err, "Error parsing start date %s", j.StartDate))
+				log.Error(errors.Wrapf(err, "Error parsing start date %s", j.StartDate))
 				continue
 			}
 			comparisonTimestamp = sd

--- a/main.go
+++ b/main.go
@@ -299,12 +299,13 @@ func sendPeriodic(ctx context.Context, db *sql.DB, vicedb *VICEDatabaser) {
 
 			periodDuration = 14400 * time.Second
 			if notifStatuses.PeriodicWarningPeriod > 0 {
-				periodDuration = notifStatuses.PeriodicWarningPeriod * time.Second
+				periodDuration = time.Duration(notifStatuses.PeriodicWarningPeriod) * time.Second
 			}
 
-			comparisonTimestamp = j.StartDate
-			if notifStatuses.LastPeriodicWarning.After(j.StartDate) {
-				comparisonTimestamp = notifStatuses.lastPeriodicWarning
+			sd, err := time.Parse(TimestampFromDBFormat, j.StartDate)
+			comparisonTimestamp = sd
+			if notifStatuses.LastPeriodicWarning.After(sd) {
+				comparisonTimestamp = notifStatuses.LastPeriodicWarning
 			}
 
 			log.Infof("Comparing last-warning timestamp %s with period %s s", comparisonTimestamp, periodDuration)

--- a/notifications.go
+++ b/notifications.go
@@ -37,6 +37,20 @@ Please finish any work that is in progress. Output files will be transferred to 
 // to users when their job is going to terminate in the near future.
 const WarningSubjectFormat = "Analysis %s will terminate on %s (%s)."
 
+// PeriodicMessageFormat is the parameterized message that gets sent to users
+// when it's time to send a regular reminder the job is still running
+// parameters: analysis name & ID, start date, duration
+const PeriodicMessageFormat = `Analysis "%s" (%s) is still running.
+
+This is a regularly scheduled reminder message to ensure you don't use up your quota.
+
+This job has been running since %s (%s).`
+
+// PeriodicSubjectFormat is the parameterized subject for the email that is sent
+// to users as a regular reminder of a running job
+// parameters: analysis name, start date, duration
+const PeriodicSubjectFormat = `Analysis %s is running since %s (%s)`
+
 // Notification is a message intended as a notification to some upstream service
 // or the DE UI.
 type Notification struct {


### PR DESCRIPTION
Okay, I _think_ this is ready to get some eyes on it. How this should work is:

* on each timelord "tick", query database for running jobs that lack a notif_statuses table entry or a last_periodic_warning within that table, or whose last periodic warning plus their periodic warning period is earlier than the current timestamp (is this good? unsure if I'd be doing too many queries or anything this way)
* for each of those jobs, ensure a notif_statuses entry and recheck if a notification should be sent, and if so, do that and then update the timestamp in the database

Right now this is using a default value for the warning period (14400s, so 4 hours). I think that should come from preferences, but I'd like to get more of this wired up and then come back to that, if I can.

As far as review, I'm worried I've got an inequality backwards somewhere or that I'm going to end up spamming the database with queries/bog things down in general. But all review is welcome, I'm not super familiar with timelord even now.