### PR TITLE
Ensure planned end dates are set a little bit better

### DIFF
--- a/main.go
+++ b/main.go
@@ -291,6 +291,10 @@ func sendPeriodic(ctx context.Context, db *sql.DB, vicedb *VICEDatabaser) {
 				periodDuration      time.Duration
 			)
 
+			if err = EnsurePlannedEndDate(ctx, db, &j); err != nil {
+				log.Error(errors.Wrapf(err, "Error ensuring a planned end date for job %s", j.ID))
+			}
+
 			// fetch preferences and update in the DB if needed
 			if err = ensureNotifRecord(ctx, vicedb, j); err != nil {
 				log.Error(err)

--- a/main.go
+++ b/main.go
@@ -62,7 +62,7 @@ func sendNotif(ctx context.Context, j *Job, status, subject, msg string) error {
 	}
 
 	u := ParseID(j.User)
-	sd, err := time.Parse(TimestampFromDBFormat, j.StartDate)
+	sd, err := time.ParseInLocation(TimestampFromDBFormat, j.StartDate, time.Local)
 	if err != nil {
 		return errors.Wrapf(err, "failed to parse %s", j.StartDate)
 	}
@@ -125,7 +125,7 @@ func ConfigureUserLookups(cfg *viper.Viper) error {
 // their job has been killed.
 func SendKillNotification(ctx context.Context, j *Job, killNotifKey string) error {
 	subject := fmt.Sprintf(KillSubjectFormat, j.Name)
-	endtime, err := time.Parse(TimestampFromDBFormat, j.PlannedEndDate)
+	endtime, err := time.ParseInLocation(TimestampFromDBFormat, j.PlannedEndDate, time.Local)
 	if err != nil {
 		return errors.Wrapf(err, "failed to parse planned end date %s", j.PlannedEndDate)
 	}
@@ -144,7 +144,7 @@ func SendKillNotification(ctx context.Context, j *Job, killNotifKey string) erro
 // SendWarningNotification sends a notification to the user telling them that
 // their job will be killed in the near future.
 func SendWarningNotification(ctx context.Context, j *Job) error {
-	endtime, err := time.Parse(TimestampFromDBFormat, j.PlannedEndDate)
+	endtime, err := time.ParseInLocation(TimestampFromDBFormat, j.PlannedEndDate, time.Local)
 	if err != nil {
 		return errors.Wrapf(err, "failed to parse planned end date %s", j.PlannedEndDate)
 	}


### PR DESCRIPTION
This does two things, plus one small thing:

a.) splits out the handling to ensure a subdomain is set, and the handling to ensure a planned end date is set, into their own functions
b.) calls the planned end date one within the periodic warnings loop (because the job kill warnings one depends on planned end date already being set), so if there's a race condition with the AMQP messages that prevents it being set by that route, it'll still get set by the periodic warnings process.

and:

c.) Uses time.ParseInLocation to hopefully set a more correct planned end date. I think, anyway.

Would definitely appreciate some close reviews to be sure I didn't inadvertently change something critical about exactly when things are run and not. Moving a lot of code around here.