### PR TITLE
Periodic notification preferences

### DIFF
--- a/analyses.go
+++ b/analyses.go
@@ -70,8 +70,8 @@ select jobs.id,
        jobs.start_date,
        job_types.system_id,
        users.username,
-       (jobs.submission->>'notify_periodic')::bool AS notify_periodic,
-       (jobs.submission->>'periodic_period')::int AS periodic_period
+       COALESCE((jobs.submission->>'notify_periodic')::bool, TRUE) AS notify_periodic,
+       COALESCE((jobs.submission->>'periodic_period')::int, 0) AS periodic_period
   from jobs
   join job_types on jobs.job_type_id = job_types.id
   join users on jobs.user_id = users.id
@@ -185,8 +185,8 @@ SELECT jobs.id,
        jobs.start_date,
        job_types.system_id,
        users.username,
-       (jobs.submission->>'notify_periodic')::bool AS notify_periodic,
-       (jobs.submission->>'periodic_period')::int AS periodic_period
+       COALESCE((jobs.submission->>'notify_periodic')::bool, TRUE) AS notify_periodic,
+       COALESCE((jobs.submission->>'periodic_period')::int, 0) AS periodic_period
   FROM jobs
   JOIN job_types on jobs.job_type_id = job_types.id
   JOIN users on jobs.user_id = users.id
@@ -277,8 +277,8 @@ select jobs.id,
        jobs.start_date,
        job_types.system_id,
        users.username,
-       (jobs.submission->>'notify_periodic')::bool AS notify_periodic,
-       (jobs.submission->>'periodic_period')::int AS periodic_period
+       COALESCE((jobs.submission->>'notify_periodic')::bool, TRUE) AS notify_periodic,
+       COALESCE((jobs.submission->>'periodic_period')::int, 0) AS periodic_period
   from jobs
   join job_types on jobs.job_type_id = job_types.id
   join users on jobs.user_id = users.id
@@ -487,8 +487,8 @@ select jobs.id,
        jobs.start_date,
        job_types.system_id,
        users.username,
-       (jobs.submission->>'notify_periodic')::bool AS notify_periodic,
-       (jobs.submission->>'periodic_period')::int AS periodic_period,
+       COALESCE((jobs.submission->>'notify_periodic')::bool, TRUE) AS notify_periodic,
+       COALESCE((jobs.submission->>'periodic_period')::int, 0) AS periodic_period,
        job_steps.external_id
   from jobs
   join job_types on jobs.job_type_id = job_types.id

--- a/main.go
+++ b/main.go
@@ -83,7 +83,7 @@ func sendNotif(ctx context.Context, j *Job, status, subject, msg, email_template
 	p.Email = user.Email
 	p.User = u
 
-	notif := NewNotification(u, subject, msg, email_template, p)
+	notif := NewNotification(u, subject, msg, true, email_template, p)
 
 	resp, err := notif.Send(ctx)
 	if err != nil {

--- a/notifications.go
+++ b/notifications.go
@@ -85,14 +85,14 @@ func NewPayload() *Payload {
 }
 
 // NewNotification returns a newly initialized *Notification.
-func NewNotification(user, subject, msg, emailTemplate string, payload *Payload) *Notification {
+func NewNotification(user, subject, msg string, email bool, emailTemplate string, payload *Payload) *Notification {
 	return &Notification{
 		URI:           NotifsURI,
 		Type:          "analysis",
 		User:          user,
 		Subject:       subject,
 		Message:       msg,
-		Email:         true,
+		Email:         email,
 		EmailTemplate: emailTemplate,
 		Payload:       payload,
 	}

--- a/notifications_test.go
+++ b/notifications_test.go
@@ -24,7 +24,7 @@ func TestNewNotification(t *testing.T) {
 	expectedSubject := "subject"
 	expectedTemplate := "analysis_status_change"
 	NotifsInit(expectedURI)
-	n := NewNotification(expectedUser, expectedSubject, "", expectedTemplate, nil)
+	n := NewNotification(expectedUser, expectedSubject, "", true, expectedTemplate, nil)
 	if n.URI != expectedURI {
 		t.Errorf("URI was %s, not %s", n.URI, expectedURI)
 	}
@@ -42,7 +42,7 @@ func TestNewNotification(t *testing.T) {
 func TestSend(t *testing.T) {
 	expectedUser := "test-user"
 	expectedSubject := "test-subject"
-	n := NewNotification(expectedUser, expectedSubject, "", "analysis_status_change", nil)
+	n := NewNotification(expectedUser, expectedSubject, "", true, "analysis_status_change", nil)
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		b, err := io.ReadAll(r.Body)

--- a/vicedb.go
+++ b/vicedb.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"database/sql"
+	"fmt"
 	"time"
 
 	pqinterval "github.com/sanyokbig/pqinterval"
@@ -110,14 +111,21 @@ func (v *VICEDatabaser) AddNotifRecord(ctx context.Context, job *Job) (string, e
 	var (
 		err     error
 		notifID string
+		period  string
 	)
+
+	if job.PeriodicPeriod > 0 {
+		period = fmt.Sprintf("%d seconds", job.PeriodicPeriod)
+	} else {
+		period = "4 hours"
+	}
 
 	if err = v.db.QueryRowContext(
 		ctx,
 		addNotifRecordQuery,
 		job.ID,
 		job.ExternalID,
-		"4 hours", // hardcoded for now
+		period,
 	).Scan(&notifID); err != nil {
 		return "", err
 	}


### PR DESCRIPTION
These changes should make it so timelord respects the notification preferences stored in the job submission. NotifyPeriodic denotes whether emails should be sent for periodic notifications, not whether the notifications should be sent at all.